### PR TITLE
Fix compilation with rustup's musl toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jirutka/setup-alpine@v1
         with:
-          packages: build-base clang-libs cmake make rustup sudo
+          packages: build-base clang-libs cmake make pkgconf rustup sudo
       - name: Setup sudo
         run: |
           echo "$USER ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/$USER

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Test (on Ubuntu Latest)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,6 +16,20 @@ jobs:
       - uses: msrd0/install-rlottie-action@v1
       - run: cargo test --workspace
   
+  test-alpine:
+    name: Test (on Alpine Latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: jirutka/setup-alpine@v1
+        with:
+          packages: build-base clang-libs cmake make
+      - uses: msrd0/install-rlottie-action@v1
+        with:
+          shell: alpine.sh {0}
+      - run: cargo test --workspace
+        shell: alpine.sh {0}
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jirutka/setup-alpine@v1
         with:
-          packages: build-base clang-libs cmake make
+          packages: build-base clang-libs cmake make sudo
+      - run: echo "$USER ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/$USER
+        shell: alpine.sh -r {0}
       - uses: msrd0/install-rlottie-action@v1
         with:
           shell: alpine.sh {0}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,8 @@ jobs:
       - uses: jirutka/setup-alpine@v1
         with:
           packages: build-base clang-libs cmake make sudo
-      - run: echo "$USER ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/$USER
+      - run: |
+          echo "$USER ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/$USER
         shell: alpine.sh -r {0}
       - uses: msrd0/install-rlottie-action@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,14 +23,27 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jirutka/setup-alpine@v1
         with:
-          packages: build-base clang-libs cmake make sudo
-      - run: |
+          packages: build-base clang-libs cmake make rustup sudo
+      - name: Setup sudo
+        run: |
           echo "$USER ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/$USER
         shell: alpine.sh -r {0}
       - uses: msrd0/install-rlottie-action@v1
         with:
           shell: alpine.sh {0}
-      - run: cargo test --workspace
+      - name: Setup Rust
+        run: |
+          export CARGO_HOME=target/cargo
+          rustup-init -qy --default-host x86_64-unknown-linux-musl --default-toolchain none </dev/null
+          source $CARGO_HOME/env
+          rustup toolchain install stable --profile minimal
+          cargo -V
+        shell: alpine.sh {0}
+      - name: Run Tests
+        run: |
+          export CARGO_HOME=target/cargo
+          source $CARGO_HOME/env
+          cargo test --workspace
         shell: alpine.sh {0}
 
   rustfmt:


### PR DESCRIPTION
Rustup's musl toolchain is broken by design and doesn't allow dynamically loading libclang. However, cargo doesn't seem to support different features based on cfg, so there isn't much we can do about it right now.