### PR TITLE
WIP: add option to complie rlottie

### DIFF
--- a/rlottie-sys/Cargo.toml
+++ b/rlottie-sys/Cargo.toml
@@ -17,4 +17,5 @@ links = "rlottie"
 
 [build-dependencies]
 bindgen = { version = "0.68.1", features = ["prettyplease", "runtime"], default-features = false }
+cmake = "0.1.50"
 pkg-config = "0.3.22"

--- a/rlottie-sys/build.rs
+++ b/rlottie-sys/build.rs
@@ -1,6 +1,45 @@
-use std::{env, path::PathBuf};
+use std::{env, fs::remove_dir_all, path::PathBuf, process::Command};
 
 fn main() {
+	let lottie_version = "v0.2";
+	let output = PathBuf::from(env::var("OUT_DIR").unwrap());
+	let clone_dest_dir = format!("lottie-source-{}", lottie_version);
+	let lottie_source_dir = output.join(&clone_dest_dir);
+	let lottie_install_dir= output.join(format!("lottie-install-{}", lottie_version));
+	let _ = remove_dir_all(&lottie_source_dir); //avoid error at cloning if folder already exist
+	let status = Command::new("git")
+		.current_dir(&output)
+		.arg("clone")
+		.arg("--depth=1")
+		.arg("--branch")
+		.arg(lottie_version)
+		.arg("https://github.com/Samsung/rlottie.git")
+		.arg(&clone_dest_dir)
+		.status()
+		.unwrap();
+	if !status.success() {
+		panic!("fetch lottie failed");
+	}
+	// rlottie needs patch for newer compilers
+	let status = Command::new("wget").current_dir(&lottie_source_dir).args(["-qO","patch","https://github.com/Samsung/rlottie/commit/2d7b1fa2b005bba3d4b45e8ebfa632060e8a157a.patch"])
+    .status().unwrap();
+	if !status.success() {
+		panic!("fetch patch failed");
+	}
+	let status = Command::new("patch")
+		.current_dir(&lottie_source_dir)
+		.args(["-N", "-p1", "-i", "patch"])
+		.status()
+		.unwrap();
+	if !status.success() {
+		panic!("apply patch failed");
+	}
+	// build lottie
+	let dst = cmake::Config::new(lottie_source_dir)
+		.define("CMAKE_INSTALL_PREFIX", &lottie_install_dir)
+		.build();
+	
+	panic!("sucess");
 	pkg_config::Config::new()
 		.probe("rlottie")
 		.expect("Unable to find rlottie");


### PR DESCRIPTION
I start adding an option to build rlottie. Sadly I can not figure out how to stop rlottie from copy things to `/usr/lib/pkgconfig` after build.