### PR TITLE
Allow for pkg-config include headers

### DIFF
--- a/rlottie-sys/build.rs
+++ b/rlottie-sys/build.rs
@@ -16,7 +16,7 @@ fn main() {
 	let bindings = bindgen::Builder::default()
 		.formatter(bindgen::Formatter::Prettyplease)
 		.header("wrapper.h")
-        .clang_args(&include_args) // Add include paths
+		.clang_args(&include_args) // Add include paths
 		.parse_callbacks(Box::new(bindgen::CargoCallbacks))
 		.newtype_enum(".*")
 		.size_t_is_usize(true)

--- a/rlottie-sys/build.rs
+++ b/rlottie-sys/build.rs
@@ -1,14 +1,22 @@
 use std::{env, path::PathBuf};
 
 fn main() {
-	pkg_config::Config::new()
+	let rlottie_pkg = pkg_config::Config::new()
 		.probe("rlottie")
 		.expect("Unable to find rlottie");
-
+	
+	// Extract include paths from the pkg-config metadata
+	let include_args: Vec<String> = rlottie_pkg
+		.include_paths
+		.iter()
+		.map(|path| format!("-I{}", path.display()))
+		.collect();
+	
 	println!("cargo:rerun-if-changed=wrapper.h");
 	let bindings = bindgen::Builder::default()
 		.formatter(bindgen::Formatter::Prettyplease)
 		.header("wrapper.h")
+        .clang_args(&include_args) // Add include paths
 		.parse_callbacks(Box::new(bindgen::CargoCallbacks))
 		.newtype_enum(".*")
 		.size_t_is_usize(true)


### PR DESCRIPTION
On MacOS, when installing rlottie, the headers get installed to a custom location. pkg-config can find these headers, but they need to be passed to clang.